### PR TITLE
Add become directive to clear old installation folder

### DIFF
--- a/tasks/linux-deploy.yml
+++ b/tasks/linux-deploy.yml
@@ -76,4 +76,3 @@
   become: yes
   notify:
     - start the service
-    

--- a/tasks/linux-deploy.yml
+++ b/tasks/linux-deploy.yml
@@ -17,6 +17,7 @@
   file: 
     path: "{{ installation_folder }}"
     state: absent
+  become: yes
   when: clear_before_install == True
 
 


### PR DESCRIPTION
This ensures the "clear old installation folder" task in the web-studio role will run with sudo/root privileges

Jenkins build fails to delete files https://qa-jenkins.experitest.com/job/Web%20Studios%20Frontend/18276/console